### PR TITLE
Adds support for reading in configuration values

### DIFF
--- a/plugins/metrics-node/package.json
+++ b/plugins/metrics-node/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.4.0",
+    "@backstage/config": "^1.3.2",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/resources": "^2.0.1",
     "@opentelemetry/sdk-metrics": "^2.0.1",

--- a/plugins/metrics-node/src/config/createDefaultMetricsConfig.ts
+++ b/plugins/metrics-node/src/config/createDefaultMetricsConfig.ts
@@ -1,0 +1,19 @@
+import { MetricsCollectionConfig, ResourceConfig, MetricsConfig } from "./types";
+
+const collectionConfig: Required<MetricsCollectionConfig> = {
+  exportIntervalMillis: 60000,
+  exportTimeoutMillis: 5000,
+};
+
+const resourceConfig: Required<ResourceConfig> = {
+  serviceName: 'backstage',
+  serviceVersion: '0.0.0',
+};
+
+export const createDefaultMetricsConfig = (): Required<MetricsConfig> => {
+  return {
+    enabled: true,
+    resource: resourceConfig,
+    collection: collectionConfig,
+  };
+};

--- a/plugins/metrics-node/src/config/index.ts
+++ b/plugins/metrics-node/src/config/index.ts
@@ -1,0 +1,3 @@
+export { readMetricsConfig } from './readMetricsConfig';
+
+export * from './types';

--- a/plugins/metrics-node/src/config/readMetricsConfig.ts
+++ b/plugins/metrics-node/src/config/readMetricsConfig.ts
@@ -1,0 +1,23 @@
+import { Config } from '@backstage/config';
+import { MetricsConfig } from './types';
+import { createDefaultMetricsConfig } from './createDefaultMetricsConfig';
+
+export function readMetricsConfig(config: Config): MetricsConfig {
+  const metricsConfig = config.getOptionalConfig('backend.metrics');
+
+  if (!metricsConfig) {
+    return createDefaultMetricsConfig();
+  }
+
+  return {
+    enabled: metricsConfig.getOptionalBoolean('enabled'),
+    resource: {
+      serviceName: metricsConfig.getOptionalString('resource.serviceName'),
+      serviceVersion: metricsConfig.getOptionalString('resource.serviceVersion'),
+    },
+    collection: {
+      exportIntervalMillis: metricsConfig.getOptionalNumber('collection.exportIntervalMillis'),
+      exportTimeoutMillis: metricsConfig.getOptionalNumber('collection.exportTimeoutMillis'),
+    },
+  };
+}

--- a/plugins/metrics-node/src/config/types.ts
+++ b/plugins/metrics-node/src/config/types.ts
@@ -1,0 +1,16 @@
+
+export interface ResourceConfig {
+  serviceName?: string;
+  serviceVersion?: string;
+}
+
+export interface MetricsCollectionConfig {
+  exportIntervalMillis?: number;
+  exportTimeoutMillis?: number;
+}
+
+export interface MetricsConfig {
+  enabled?: boolean;
+  resource?: ResourceConfig;
+  collection?: MetricsCollectionConfig;
+}

--- a/plugins/metrics-node/src/services/RootMetricsService/createRootMetricsService.ts
+++ b/plugins/metrics-node/src/services/RootMetricsService/createRootMetricsService.ts
@@ -10,10 +10,17 @@ import { MetricsService, RootMetricsService, MetricsServicePluginOptions } from 
 import { MetricOptions } from '../../types';
 import { PluginMetricsService } from '../PluginMetricsService';
 import { CounterMetric, createCounterMetric, UpDownCounterMetric, createUpDownCounterMetric } from '../../instruments/counter';
+import { MetricsConfig } from '../../config';
 
-export async function createRootMetricsService(): Promise<RootMetricsService> {
-  const rootServiceName = 'backstage';
-  const rootServiceVersion = '0.0.0';
+interface RootMetricsServiceOptions {
+  config: MetricsConfig;
+}
+
+export async function createRootMetricsService(options: RootMetricsServiceOptions): Promise<RootMetricsService> {
+  const { config } = options;
+
+  const rootServiceName = config.resource?.serviceName ?? 'backstage';
+  const rootServiceVersion = config.resource?.serviceVersion ?? '0.0.0';
 
   const resource = defaultResource().merge(
     resourceFromAttributes({
@@ -24,7 +31,7 @@ export async function createRootMetricsService(): Promise<RootMetricsService> {
 
   const metricReader = new PeriodicExportingMetricReader({
     exporter: new ConsoleMetricExporter(),
-    exportIntervalMillis: 60000, // 60 seconds
+    exportIntervalMillis: config.collection?.exportIntervalMillis ?? 60000, // 60 seconds
   });
 
   const provider = new MeterProvider({

--- a/plugins/metrics-node/src/services/RootMetricsService/rootMetricsServiceFactory.ts
+++ b/plugins/metrics-node/src/services/RootMetricsService/rootMetricsServiceFactory.ts
@@ -1,6 +1,7 @@
 import { coreServices, createServiceFactory, createServiceRef } from "@backstage/backend-plugin-api";
 import { createRootMetricsService } from "./createRootMetricsService";
 import { RootMetricsService } from "../../definitions";
+import { readMetricsConfig } from "../../config";
 
 /**
  * Service reference for the root metrics service.
@@ -21,10 +22,13 @@ export const rootMetricsServiceFactory = createServiceFactory({
   service: rootMetricsServiceRef,
   deps: {
     rootLogger: coreServices.rootLogger,
+    rootConfig: coreServices.rootConfig,
   },
-  async factory({ rootLogger }) {
+  async factory({ rootLogger, rootConfig }) {
     rootLogger.info('Creating root metrics service');
 
-    return await createRootMetricsService();
+    return await createRootMetricsService({
+      config: readMetricsConfig(rootConfig),
+    });
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7309,6 +7309,7 @@ __metadata:
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.4.0"
     "@backstage/cli": "npm:^0.33.0"
+    "@backstage/config": "npm:^1.3.2"
     "@opentelemetry/api": "npm:^1.9.0"
     "@opentelemetry/resources": "npm:^2.0.1"
     "@opentelemetry/sdk-metrics": "npm:^2.0.1"


### PR DESCRIPTION
Includes adding default configuration options, enabling dynamic configuration reading, and integrating the configuration into the metrics service creation process.

### Configuration Enhancements:

* Added a `createDefaultMetricsConfig` function to provide default values for metrics settings, including resource details and collection intervals.
* Implemented a `readMetricsConfig` function to read optional metrics configuration from the Backstage `Config` object, falling back to defaults when not provided. 
* Updated `createRootMetricsService` to accept a `MetricsConfig` object, allowing dynamic configuration of resource details and collection intervals.
* Modified `rootMetricsServiceFactory` to read configuration using the new `readMetricsConfig` function and pass it to the service creation process.
* Added type definitions for `MetricsConfig`, `ResourceConfig`, and `MetricsCollectionConfig` to ensure type safety across the configuration system. 